### PR TITLE
29 responsive sidebar

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,7 +1,14 @@
 <template>
   <v-app>
-    <toolbar />
-
+    <toolbar
+      :items="navigation"
+      @click-hamburger="clickHamburger"
+    />
+    <sidebar
+      v-if="$vuetify.breakpoint.smAndDown"
+      :show="showSidebar"
+      :items="navigation"
+    />
     <v-content>
       <router-view />
     </v-content>
@@ -10,16 +17,39 @@
 
 <script>
 import Toolbar from './components/Toolbar.vue';
+import Sidebar from './components/Sidebar.vue';
 
 export default {
   name: 'App',
 
   components: {
     Toolbar,
+    Sidebar,
   },
-
+  computed: {
+    navigation() {
+      return [
+        {
+          title: "Home",
+          icon: "home",
+          path: "/",
+          hideInToolbar: true,
+        },
+        {
+          title: "About",
+          icon: "help",
+          path: "about"
+        }
+      ];
+    }
+  },
   data: () => ({
-    //
+    showSidebar: false,
   }),
+  methods: {
+    clickHamburger() {
+      this.showSidebar = !this.showSidebar;
+    },
+  },
 };
 </script>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -2,7 +2,7 @@
   <v-app>
     <toolbar
       :items="navigation"
-      @click-hamburger="clickHamburger"
+      @click-menu="clickMenu"
     />
     <sidebar
       v-if="$vuetify.breakpoint.smAndDown"
@@ -48,7 +48,7 @@ export default {
     },
   },
   methods: {
-    clickHamburger() {
+    clickMenu() {
       this.showSidebar = !this.showSidebar;
     },
   },

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -27,26 +27,26 @@ export default {
     Toolbar,
     Sidebar,
   },
+  data: () => ({
+    showSidebar: false,
+  }),
   computed: {
     navigation() {
       return [
         {
-          title: "Home",
-          icon: "home",
-          path: "/",
+          title: 'Home',
+          icon: 'home',
+          path: '/',
           hideInToolbar: true,
         },
         {
-          title: "About",
-          icon: "help",
-          path: "about"
-        }
+          title: 'About',
+          icon: 'help',
+          path: 'about',
+        },
       ];
-    }
+    },
   },
-  data: () => ({
-    showSidebar: false,
-  }),
   methods: {
     clickHamburger() {
       this.showSidebar = !this.showSidebar;

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -8,6 +8,7 @@
       v-if="$vuetify.breakpoint.smAndDown"
       :show="showSidebar"
       :items="navigation"
+      @close-drawer="showSidebar = false"
     />
     <v-content>
       <router-view />

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -1,0 +1,50 @@
+<template>
+  <v-navigation-drawer
+    v-model="drawer"
+    app
+    right
+    dark
+    color="primary"
+  >
+    <v-list>
+      <div v-for="item in items"
+          :key="item.title">
+        <v-list-item
+          :href="item.path"
+          link
+        >
+          <v-list-item-icon>
+            <v-icon>{{ item.icon }}</v-icon>
+          </v-list-item-icon>
+
+          <v-list-item-content>
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </div>
+    </v-list>
+  </v-navigation-drawer>
+</template>
+
+<script>
+export default {
+  props: {
+    show: {
+      type: Boolean,
+      required: true,
+    },
+    items: {
+      type: Array,
+      required: true,
+    }
+  },
+  data: () => ({
+    drawer: false,
+  }),
+  watch: {
+    show() {
+      this.drawer = this.show;
+    },
+  },
+};
+</script>

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -35,6 +35,9 @@
 import LanguageSwitcher from './LanguageSwitcher.vue';
 
 export default {
+  components: {
+    LanguageSwitcher,
+  },
   props: {
     show: {
       type: Boolean,
@@ -44,9 +47,6 @@ export default {
       type: Array,
       required: true,
     },
-  },
-  components: {
-    LanguageSwitcher
   },
   data: () => ({
     drawer: false,

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -7,8 +7,10 @@
     color="primary"
   >
     <v-list>
-      <div v-for="item in items"
-          :key="item.title">
+      <div
+        v-for="item in items"
+        :key="item.title"
+      >
         <v-list-item
           :href="item.path"
           link
@@ -36,7 +38,7 @@ export default {
     items: {
       type: Array,
       required: true,
-    }
+    },
   },
   data: () => ({
     drawer: false,
@@ -47,9 +49,9 @@ export default {
     },
     drawer() {
       if (!this.drawer) {
-              this.$emit('close-drawer')
+        this.$emit('close-drawer');
       }
-    }
+    },
   },
 };
 </script>

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -24,11 +24,16 @@
           </v-list-item-content>
         </v-list-item>
       </div>
+      <v-list-item>
+        <language-switcher />
+      </v-list-item>
     </v-list>
   </v-navigation-drawer>
 </template>
 
 <script>
+import LanguageSwitcher from './LanguageSwitcher.vue';
+
 export default {
   props: {
     show: {
@@ -39,6 +44,9 @@ export default {
       type: Array,
       required: true,
     },
+  },
+  components: {
+    LanguageSwitcher
   },
   data: () => ({
     drawer: false,

--- a/web/src/components/Sidebar.vue
+++ b/web/src/components/Sidebar.vue
@@ -45,6 +45,11 @@ export default {
     show() {
       this.drawer = this.show;
     },
+    drawer() {
+      if (!this.drawer) {
+              this.$emit('close-drawer')
+      }
+    }
   },
 };
 </script>

--- a/web/src/components/Toolbar.vue
+++ b/web/src/components/Toolbar.vue
@@ -18,13 +18,20 @@
 
     <v-spacer />
 
-    <v-toolbar-items class="d-flex align-center" v-if="$vuetify.mdAndUp">
-      <v-btn
-        text
-        href="about"
+    <v-toolbar-items
+      v-if="$vuetify.breakpoint.mdAndUp"
+      class="d-flex align-center"
+    >
+      <div v-for="item in filteredItems"
+        :key="item.title"
       >
-        About
-      </v-btn>
+        <v-btn
+          text
+          :href="item.path"
+        >
+          {{ item.title }}
+        </v-btn>
+      </div>
       <v-divider
         class="mx-4"
         inset
@@ -33,7 +40,10 @@
       <language-switcher />
     </v-toolbar-items>
     <v-toolbar-items v-else>
-      <v-btn text>
+      <v-btn
+        text
+        @click="$emit('click-hamburger')"
+      >
         <v-icon>menu</v-icon>
       </v-btn>
     </v-toolbar-items>
@@ -45,12 +55,24 @@
 import LanguageSwitcher from './LanguageSwitcher.vue';
 
 export default {
+  props: {
+    items: {
+      type: Array,
+      required: true,
+    }
+  },
   components: {
     LanguageSwitcher,
   },
+  computed: {
+    // some navigation items aren't meant for display in the toolbar, so filter
+    // them out
+    filteredItems() {
+      return this.items.filter((item) => { return !item.hideInToolbar })
+    }
+  },
   data() {
     return {
-
     };
   },
 };

--- a/web/src/components/Toolbar.vue
+++ b/web/src/components/Toolbar.vue
@@ -22,7 +22,8 @@
       v-if="$vuetify.breakpoint.mdAndUp"
       class="d-flex align-center"
     >
-      <div v-for="item in filteredItems"
+      <div
+        v-for="item in filteredItems"
         :key="item.title"
       >
         <v-btn
@@ -55,25 +56,25 @@
 import LanguageSwitcher from './LanguageSwitcher.vue';
 
 export default {
+  components: {
+    LanguageSwitcher,
+  },
   props: {
     items: {
       type: Array,
       required: true,
-    }
+    },
   },
-  components: {
-    LanguageSwitcher,
+  data() {
+    return {
+    };
   },
   computed: {
     // some navigation items aren't meant for display in the toolbar, so filter
     // them out
     filteredItems() {
-      return this.items.filter((item) => { return !item.hideInToolbar })
-    }
-  },
-  data() {
-    return {
-    };
+      return this.items.filter((item) => !item.hideInToolbar);
+    },
   },
 };
 </script>

--- a/web/src/components/Toolbar.vue
+++ b/web/src/components/Toolbar.vue
@@ -18,7 +18,7 @@
 
     <v-spacer />
 
-    <v-toolbar-items class="d-flex align-center">
+    <v-toolbar-items class="d-flex align-center" v-if="$vuetify.mdAndUp">
       <v-btn
         text
         href="about"
@@ -31,6 +31,11 @@
         vertical
       />
       <language-switcher />
+    </v-toolbar-items>
+    <v-toolbar-items v-else>
+      <v-btn text>
+        <v-icon>menu</v-icon>
+      </v-btn>
     </v-toolbar-items>
   </v-app-bar>
 </template>

--- a/web/src/components/Toolbar.vue
+++ b/web/src/components/Toolbar.vue
@@ -43,7 +43,7 @@
     <v-toolbar-items v-else>
       <v-btn
         text
-        @click="$emit('click-hamburger')"
+        @click="$emit('click-menu')"
       >
         <v-icon>menu</v-icon>
       </v-btn>


### PR DESCRIPTION
- Add in a sidebar for mobile devices (xs and s breakpoints)
- Be able to toggle the sidebar with a 🍔 hamburger menu, and dismiss by clicking off the sidebar
- DRY up the navigation between the sidebar and top bar
- Add the locale switcher to the sidebar (future styling may happen after @yanarchy lands her changes)