### PR TITLE
37 landing page tweaks

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -13,10 +13,12 @@
     <v-content>
       <router-view />
     </v-content>
+    <app-footer />
   </v-app>
 </template>
 
 <script>
+import AppFooter from '@/components/AppFooter.vue';
 import Toolbar from './components/Toolbar.vue';
 import Sidebar from './components/Sidebar.vue';
 
@@ -26,6 +28,7 @@ export default {
   components: {
     Toolbar,
     Sidebar,
+    AppFooter,
   },
   data: () => ({
     showSidebar: false,

--- a/web/src/components/AppFooter.vue
+++ b/web/src/components/AppFooter.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-footer
+    color="primary"
+    dark
+    app
+    absolute
+  >
+    <v-row
+      justify="center"
+      align="center"
+    >
+      2020 SpeakHer
+    </v-row>
+  </v-footer>
+</template>
+
+<script>
+export default {
+
+};
+</script>

--- a/web/src/components/about/Summary.vue
+++ b/web/src/components/about/Summary.vue
@@ -15,7 +15,7 @@
 
         <v-row
           justify="center"
-          class="mb-5 mt-4"
+          class="mt-10"
         >
           <v-btn
             outlined

--- a/web/src/components/about/Summary.vue
+++ b/web/src/components/about/Summary.vue
@@ -1,0 +1,31 @@
+<template>
+  <v-container>
+    <v-row
+      justify="center"
+      no-gutters
+    >
+      <v-col lg="10">
+        <h2>Want to find female speakers for your next event?</h2>
+        <br>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptatem,
+          vero magni delectus optio dignissimos harum. Animi tempore cum fugiat
+          dolorem assumenda corporis porro, vel fugit ad voluptatibus sapiente! Non, quos?
+        </p>
+
+        <v-row
+          justify="center"
+          class="mb-5 mt-4"
+        >
+          <v-btn
+            outlined
+            color="primary"
+            to="/about"
+          >
+            Learn more
+          </v-btn>
+        </v-row>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>

--- a/web/src/components/hero/CallToAction.vue
+++ b/web/src/components/hero/CallToAction.vue
@@ -24,7 +24,7 @@
           outlined
           dark
           class="ma-2"
-          href="find-speaker"
+          @click="$vuetify.goTo('#find-speaker', options)"
         >
           Find a speaker
         </v-btn>
@@ -54,8 +54,19 @@
 export default {
   data() {
     return {
-
+      duration: 400,
+      offset: -50,
+      easing: 'easeInOutCubic',
     };
+  },
+  computed: {
+    options() {
+      return {
+        duration: this.duration,
+        offset: this.offset,
+        easing: this.easing,
+      };
+    },
   },
 };
 </script>

--- a/web/src/views/FindSpeaker.vue
+++ b/web/src/views/FindSpeaker.vue
@@ -5,6 +5,11 @@
       no-gutters
     >
       <v-col lg="10">
+        <v-row>
+          <h2 class="mx-2 mb-2">
+            Find a speaker
+          </h2>
+        </v-row>
         <search />
         <div
           v-for="speaker in speakers"

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -27,9 +27,9 @@
       </v-row>
     </v-parallax>
     <br>
-    <Summary />
-    <v-divider />
-    <find-speaker />
+    <Summary id="summary" />
+    <v-divider class="my-10" />
+    <find-speaker id="find-speaker" />
   </div>
 </template>
 

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -3,7 +3,7 @@
     <v-parallax
       dark
       src="../assets/background.png"
-      height="800"
+      height="100%"
     >
       <v-row
         no-gutters
@@ -26,18 +26,26 @@
         </v-col>
       </v-row>
     </v-parallax>
+    <br>
+    <Summary />
+    <v-divider />
+    <find-speaker />
   </div>
 </template>
 
 <script>
 import Illustration from '@/components/hero/Illustration.vue';
 import CallToAction from '@/components/hero/CallToAction.vue';
+import Summary from '@/components/about/Summary.vue';
+import FindSpeaker from '@/views/FindSpeaker.vue';
 
 export default {
   name: 'Home',
   components: {
     Illustration,
     CallToAction,
+    Summary,
+    FindSpeaker,
   },
   data() {
     return {


### PR DESCRIPTION
Resolves #37 

- Makes the home page a nice vertical scroll, inspired by #39. Add a brief summary section. 
- Make the navigation scroll down rather than navigate to a separate page
- Add a footer as a placeholder

<img width="1466" alt="web" src="https://user-images.githubusercontent.com/4602369/86507119-82b6e580-be10-11ea-92d2-545ca2ff96d6.png">

<img width="1411" alt="web" src="https://user-images.githubusercontent.com/4602369/86507103-72066f80-be10-11ea-92c9-48144f2a741b.png">
