### PR TITLE
Fetch topics from Airtable

### DIFF
--- a/web/src/components/nomination/NominateForm.vue
+++ b/web/src/components/nomination/NominateForm.vue
@@ -334,7 +334,7 @@ export default {
 
       const payload = this.parseFormData();
       if (process.env.NODE_ENV === 'production') {
-        this.$db('People').create(payload, this.afterSave);
+        this.$db('People').create(payload, { typecast: true }, this.afterSave);
       } else {
         console.log(payload);
         this.setAlert('success', this.$t('nominateSpeaker.thanks'));
@@ -345,11 +345,19 @@ export default {
     parseFormData() {
       /* eslint-disable camelcase */
 
+      // for existing topics we should send just the id
+      const topics = this.form.topics.map((elem) => {
+        if (typeof elem === 'object' && elem !== null) {
+          return elem.id;
+        }
+        return elem;
+      });
+
       // translate the fields into airtable format
       const payloadFields = {
+        topics,
         email: this.form.email,
         speaker_bio: this.form.speaker_bio,
-        topics: this.form.topics,
         languages: this.form.languages,
         photo_url: this.form.photo_url,
         name_en: this.form.name.en,

--- a/web/src/components/nomination/TopicsInput.vue
+++ b/web/src/components/nomination/TopicsInput.vue
@@ -5,7 +5,8 @@
         ref="topics"
         :label="$t('nominateSpeaker.topics')"
         :items="topics"
-        item-text="en"
+        item-text="name_en"
+        item-value="id"
         multiple
         chips
         deletable-chips
@@ -27,22 +28,20 @@ export default {
   },
   data() {
     return {
-      topics: [
-        { en: 'STEM' },
-        { en: 'Business' },
-        { en: 'Fintech' },
-        { en: 'Art' },
-      ],
+      topics: [],
       error: null,
     };
   },
   mounted() {
-    // TODO: fetch topics from database
-    // this.$getTopics(this.setTopics, this.setError);
+    this.$getTopics(this.setTopics, this.setError);
   },
   methods: {
     setTopics(records) {
-      this.topics = records;
+      this.topics = records.map((topic) => ({
+        id: topic.id,
+        name_en: topic.get('name_en'),
+        name_ja: topic.get('name_ja'),
+      }));
     },
     setError(err) {
       this.error = err;

--- a/web/src/components/nomination/TopicsInput.vue
+++ b/web/src/components/nomination/TopicsInput.vue
@@ -5,7 +5,7 @@
         ref="topics"
         :label="$t('nominateSpeaker.topics')"
         :items="topics"
-        item-text="name_en"
+        :item-text="$i18n.locale === 'ja' ? 'name_ja' : 'name_en'"
         item-value="id"
         multiple
         chips

--- a/web/src/components/nomination/TopicsInput.vue
+++ b/web/src/components/nomination/TopicsInput.vue
@@ -1,12 +1,14 @@
 <template>
   <v-row dense>
     <v-col>
-      <v-autocomplete
+      <v-combobox
         ref="topics"
-        :label="$t('nominateSpeaker.topics')"
+        :label="$t('nominateSpeaker.topics.label')"
+        :hint="$t('nominateSpeaker.topics.hint')"
         :items="topics"
         :item-text="$i18n.locale === 'ja' ? 'name_ja' : 'name_en'"
         item-value="id"
+        persistent-hint
         multiple
         chips
         deletable-chips
@@ -45,9 +47,6 @@ export default {
     },
     setError(err) {
       this.error = err;
-    },
-    addTopic() {
-      // TODO: add new topics
     },
   },
 };

--- a/web/src/components/nomination/TopicsInput.vue
+++ b/web/src/components/nomination/TopicsInput.vue
@@ -6,8 +6,6 @@
         :label="$t('nominateSpeaker.topics.label')"
         :hint="$t('nominateSpeaker.topics.hint')"
         :items="topics"
-        :item-text="$i18n.locale === 'ja' ? 'name_ja' : 'name_en'"
-        item-value="id"
         persistent-hint
         multiple
         chips
@@ -41,8 +39,7 @@ export default {
     setTopics(records) {
       this.topics = records.map((topic) => ({
         id: topic.id,
-        name_en: topic.get('name_en'),
-        name_ja: topic.get('name_ja'),
+        text: topic.get('name'),
       }));
     },
     setError(err) {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -84,7 +84,10 @@
         "submitterName": "Submitter Name",
         "thanks": "Thank you for your submission!",
         "title": "Nominate a speaker",
-        "topics": "Topics",
+        "topics": {
+            "label": "Topics",
+            "hint": "Type anything and press enter to add new topics"
+        },
         "twitter": "Twitter URL",
         "website": "Website"
     },

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -84,7 +84,10 @@
         "submitterName": "提出者",
         "thanks": "投稿ありがとうございます！",
         "title": "スピーカーを指名する",
-        "topics": "得意分野",
+        "topics": {
+            "label": "得意分野",
+            "hint": "何かを入力してEnterキーを押し、新しいトピックを追加します"
+        },
         "twitter": "TwitterのURL",
         "website": "ウェブサイト"
     },

--- a/web/src/plugins/airtable.js
+++ b/web/src/plugins/airtable.js
@@ -28,6 +28,25 @@ Airtable.install = function (Vue) {
       });
     }
   };
+
+  Vue.prototype.$topics = [];
+
+  Vue.prototype.$getTopics = function (successCallback, errorCallback) {
+    if (this.$topics.length) {
+      // return cached response
+      successCallback(this.$topics);
+    } else {
+      this.$db('Topics').select({ view: 'All' }).firstPage((error, records) => {
+        if (error) {
+          console.error(`Error fetching topics: ${error}`);
+          errorCallback(error);
+        } else {
+          this.$topics = records; // cache response
+          successCallback(records);
+        }
+      });
+    }
+  };
 };
 
 export default Airtable;


### PR DESCRIPTION
Pre-requirement to resolve #71 

Topics are now in a separate table (named `Topics`, [access with your Airtable account here](https://airtable.com/tblllBktP0o2lNo8y/viwN4bSK6NEvx0PjW?blocks=hide)), where we can set the name in any language and add new topics anytime.

<img width="458" alt="Screen Shot 2020-08-02 at 12 37 06 PM" src="https://user-images.githubusercontent.com/1096046/89114956-e76f6980-d4bc-11ea-8639-678070ac2bf1.png">

The nomination form now fetches the topics from this table and the speaker entry `has many` topics (it's a many to many relation now)

<img width="615" alt="Screen Shot 2020-08-02 at 12 01 53 PM" src="https://user-images.githubusercontent.com/1096046/89114531-6d3ce600-d4b8-11ea-825e-278f5091b83d.png">

*Specs*
- [x] Topic list is fetched from Airtable (`id`, `name`)
- [x] If we add new topics to Airtable, the dropdown list is automatically updated
- [x] Able to select multiple topics when filling the form
- [x] When the form is submitted, the topic ids are linked to the speaker entry (database relation, not a list of strings!)
- ~~[x] We can translate the topic names in the database, on the column `name_ja`~~
- [x] Switch the dropdown options between EN and JA according to the current locale setting
- [x] Users can add new topics from the form => _Merged_