### PR TITLE
Add new topic from dropdown

### DIFF
--- a/web/src/components/nomination/NominateForm.vue
+++ b/web/src/components/nomination/NominateForm.vue
@@ -334,7 +334,7 @@ export default {
 
       const payload = this.parseFormData();
       if (process.env.NODE_ENV === 'production') {
-        this.$db('People').create(payload, this.afterSave);
+        this.$db('People').create(payload, { typecast: true }, this.afterSave);
       } else {
         console.log(payload);
         this.setAlert('success', this.$t('nominateSpeaker.thanks'));
@@ -345,11 +345,19 @@ export default {
     parseFormData() {
       /* eslint-disable camelcase */
 
+      // for existing topics we should send just the id
+      const topics = this.form.topics.map((elem) => {
+        if (typeof elem === 'object' && elem !== null) {
+          return elem.id;
+        }
+        return elem;
+      });
+
       // translate the fields into airtable format
       const payloadFields = {
+        topics,
         email: this.form.email,
         speaker_bio: this.form.speaker_bio,
-        topics: this.form.topics,
         languages: this.form.languages,
         photo_url: this.form.photo_url,
         name_en: this.form.name.en,

--- a/web/src/components/nomination/TopicsInput.vue
+++ b/web/src/components/nomination/TopicsInput.vue
@@ -3,10 +3,12 @@
     <v-col>
       <v-combobox
         ref="topics"
-        :label="$t('nominateSpeaker.topics')"
+        :label="$t('nominateSpeaker.topics.label')"
+        :hint="$t('nominateSpeaker.topics.hint')"
         :items="topics"
         :item-text="$i18n.locale === 'ja' ? 'name_ja' : 'name_en'"
         item-value="id"
+        persistent-hint
         multiple
         chips
         deletable-chips

--- a/web/src/components/nomination/TopicsInput.vue
+++ b/web/src/components/nomination/TopicsInput.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row dense>
     <v-col>
-      <v-autocomplete
+      <v-combobox
         ref="topics"
         :label="$t('nominateSpeaker.topics')"
         :items="topics"
@@ -45,9 +45,6 @@ export default {
     },
     setError(err) {
       this.error = err;
-    },
-    addTopic() {
-      // TODO: add new topics
     },
   },
 };

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -84,7 +84,10 @@
         "submitterName": "Submitter Name",
         "thanks": "Thank you for your submission!",
         "title": "Nominate a speaker",
-        "topics": "Topics",
+        "topics": {
+            "label": "Topics",
+            "hint": "Type anything and press enter to add new topics"
+        },
         "twitter": "Twitter URL",
         "website": "Website"
     },

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -86,7 +86,7 @@
         "title": "スピーカーを指名する",
         "topics": {
             "label": "得意分野",
-            "hint": "Type anything and press enter to add new topics"
+            "hint": "何かを入力してEnterキーを押し、新しいトピックを追加します"
         },
         "twitter": "TwitterのURL",
         "website": "ウェブサイト"

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -84,7 +84,10 @@
         "submitterName": "提出者",
         "thanks": "投稿ありがとうございます！",
         "title": "スピーカーを指名する",
-        "topics": "得意分野",
+        "topics": {
+            "label": "得意分野",
+            "hint": "Type anything and press enter to add new topics"
+        },
         "twitter": "TwitterのURL",
         "website": "ウェブサイト"
     },


### PR DESCRIPTION
Branched out of #76 , finishes resolving #71 

- Changed `v-autocomplete` to [`v-combobox`](https://vuetifyjs.com/en/components/combobox/) to allow entering new items
- Existing items are sent as an `id` to Airtable, to make the link with the existing Topic record, new items are sent as the typed strings, to create new records with the string as the name (`name_en`)
- The magic works because the Airtable call has a parameter `typecast: true`, that makes the best effort to identify the operation (if it's an existing id, link the record, if it's not, create a new record and then link it)
- Added a small parsing logic on the payload function to make this work

**Specs:**
- [x] Users can select existing items or type something new and press enter to add
- [x] Added a persistent-hint to the Topics field, to explain how this works (it's not obvious that you can just type anything and press enter)

**Limitations:**
- Cannot translate the topic name in English and Japanese, because the new values are just one simple string

![screencast 2020-08-02 15-44-14](https://user-images.githubusercontent.com/1096046/89117242-548ff880-d4d7-11ea-9452-915d1ad5ea0b.gif)
