### PR TITLE
[Suggestion] Locale switch button show opposing language

### DIFF
--- a/web/src/components/LocaleSwitcher.vue
+++ b/web/src/components/LocaleSwitcher.vue
@@ -7,7 +7,7 @@
     <v-icon left>
       language
     </v-icon>
-    {{ locale.label }}
+    {{ switchLabel }}
   </v-btn>
 </template>
 
@@ -18,6 +18,14 @@ const { en, ja } = supportedLocales;
 
 export default {
   data: () => ({ locale: en }),
+  computed: {
+    switchLabel() {
+      if (this.locale.code === en.code) {
+        return ja.label;
+      }
+      return en.label;
+    },
+  },
   watch: {
     locale() {
       this.$i18n.locale = this.locale.code || en.code;


### PR DESCRIPTION
I was a bit confused when I saw the site in Japanese and the language switch was showing `日本語` instead of `English`.

If someone can't read Japanese, they won't know they should click the 日本語 button to change it to English, so I think it makes more sense that the button show the language to switch to, instead of the current language.

It's a suggestion, let me know what you think!
