### PR TITLE
86 sort speakers

### DIFF
--- a/web/src/plugins/airtable.js
+++ b/web/src/plugins/airtable.js
@@ -1,8 +1,7 @@
 import Airtable from 'airtable';
-
+/* eslint-disable no-param-reassign */
+/* eslint-disable func-names */
 Airtable.install = function (Vue) {
-  /* eslint-disable no-param-reassign */
-
   this.configure({
     endpointUrl: 'https://api.airtable.com',
     apiKey: process.env.VUE_APP_AIRTABLE_API_KEY,

--- a/web/src/views/FindSpeaker.vue
+++ b/web/src/views/FindSpeaker.vue
@@ -84,6 +84,9 @@ export default {
       this.$db('People')
         .select({
           view: 'Published',
+          sort: [
+            { field: 'name_en', direction: 'asc' },
+          ],
         })
         .firstPage((err, records) => {
           if (err) {


### PR DESCRIPTION
Part 1 of #86 

Sort speakers from A-Z by `name_en`.

In the future we could allow different types of sorting. 