### PR TITLE
Add some vertical space to the tags so they wrap nicely

### DIFF
--- a/web/src/components/TagBox.vue
+++ b/web/src/components/TagBox.vue
@@ -10,6 +10,7 @@
       <v-chip
         :color="generateColor(tag)"
         label
+        class="mb-2"
       >
         {{ tag }}
       </v-chip>


### PR DESCRIPTION
Part of #101 

Quick hack to fix tag wrapping for both mobile and speakers with many tags.

<img width="428" alt="SpeakHer" src="https://user-images.githubusercontent.com/4602369/92017441-c1c0d300-ed8e-11ea-8e33-476707a4afb1.png">


We can address the language placement in another PR, perhaps alongside #92 