### PR TITLE
read updated table for speaker card

### DIFF
--- a/web/src/components/CardHeader.vue
+++ b/web/src/components/CardHeader.vue
@@ -5,7 +5,7 @@
     </h2>
     <div
       v-for="language in languages"
-      :key="language"
+      :key="language.id"
       class="d-flex justify-center align-center mr-2"
     >
       <v-chip
@@ -14,7 +14,7 @@
         outlined
         small
       >
-        {{ language }}
+        {{ formatLanguage(language) }}
       </v-chip>
     </div>
     <v-spacer />
@@ -68,6 +68,11 @@ export default {
     toggleFavorite() {
       this.favorited = !this.favorited;
       // TODO: find a way to save this
+    },
+    formatLanguage(language) {
+      return (language.fields.native && language.fields.native !== '')
+        ? `${language.fields.name} - ${language.fields.native}`
+        : language.fields.name;
     },
   },
 };

--- a/web/src/components/CardHeader.vue
+++ b/web/src/components/CardHeader.vue
@@ -14,7 +14,7 @@
         outlined
         small
       >
-        {{ formatLanguage(language) }}
+        {{ format(language) }}
       </v-chip>
     </div>
     <v-spacer />
@@ -42,6 +42,8 @@
 </template>
 
 <script>
+import formatLanguage from '@/util/format';
+
 export default {
   props: {
     title: {
@@ -69,10 +71,8 @@ export default {
       this.favorited = !this.favorited;
       // TODO: find a way to save this
     },
-    formatLanguage(language) {
-      return (language.fields.native && language.fields.native !== '')
-        ? `${language.fields.name} - ${language.fields.native}`
-        : language.fields.name;
+    format(language) {
+      return formatLanguage(language);
     },
   },
 };

--- a/web/src/components/SpeakerCard.vue
+++ b/web/src/components/SpeakerCard.vue
@@ -68,7 +68,7 @@ export default {
     },
     languages() {
       const languageIds = this.speaker.get('languages2');
-      return this.languageList.filter((language) => languageIds.find((id) => (id === language.id)));
+      return this.languageList.filter((language) => languageIds.includes(language.id));
     },
     name() {
       try {

--- a/web/src/components/SpeakerCard.vue
+++ b/web/src/components/SpeakerCard.vue
@@ -7,7 +7,7 @@
       <v-col>
         <card-header
           :title="name"
-          :languages="speaker.get('languages')"
+          :languages="languages"
           @contact-speaker="contactSpeaker()"
         />
         <v-row
@@ -46,6 +46,10 @@ export default {
       type: Array,
       required: true,
     },
+    languageList: {
+      type: Array,
+      required: true,
+    },
   },
   data: () => ({
     topics: [],
@@ -61,6 +65,10 @@ export default {
       const locationId = this.speaker.fields.location_id[0];
       const location = this.prefectures.find((elem) => (elem.id === locationId));
       return location?.fields?.prefecture;
+    },
+    languages() {
+      const languageIds = this.speaker.get('languages2');
+      return this.languageList.filter((language) => languageIds.find((id) => (id === language.id)));
     },
     name() {
       try {

--- a/web/src/components/SpeakerCard.vue
+++ b/web/src/components/SpeakerCard.vue
@@ -67,7 +67,7 @@ export default {
       return location?.fields?.prefecture;
     },
     languages() {
-      const languageIds = this.speaker.get('languages2');
+      const languageIds = this.speaker.get('languages');
       return this.languageList.filter((language) => languageIds.includes(language.id));
     },
     name() {

--- a/web/src/components/nomination/LanguageInput.vue
+++ b/web/src/components/nomination/LanguageInput.vue
@@ -18,6 +18,8 @@
 </template>
 
 <script>
+import formatLanguage from '@/util/format';
+
 export default {
   props: {
     value: {
@@ -42,7 +44,7 @@ export default {
     setLanguages(records) {
       this.languages = records.map((language) => ({
         id: language.id,
-        text: language.get('name'),
+        text: formatLanguage(language),
       }));
     },
     setError(err) {

--- a/web/src/components/nomination/NominateForm.vue
+++ b/web/src/components/nomination/NominateForm.vue
@@ -356,7 +356,7 @@ export default {
         topics,
         email: this.form.email,
         speaker_bio: this.form.speaker_bio,
-        languages2: languages, // TODO: update the airtable table names in the next PR
+        languages,
         photo_url: this.form.photo_url,
         name_en: this.form.name.en,
         name_ja: this.form.name.ja,

--- a/web/src/util/format.js
+++ b/web/src/util/format.js
@@ -1,0 +1,7 @@
+
+export default function formatLanguage(language) {
+  const name = language.get('name');
+  const native = language.get('native');
+
+  return (native && native !== '') ? `${name} - ${native}` : name;
+}

--- a/web/src/views/FindSpeaker.vue
+++ b/web/src/views/FindSpeaker.vue
@@ -29,6 +29,7 @@
           <speaker-card
             :speaker="speaker"
             :prefectures="prefectures"
+            :language-list="languageList"
             class="mb-5"
           />
         </div>
@@ -54,6 +55,7 @@ export default {
   data: () => ({
     speakers: [],
     prefectures: [],
+    languageList: [],
     error: null,
     selectedSpeaker: undefined,
     showDialog: false,
@@ -66,6 +68,7 @@ export default {
   },
   mounted() {
     this.$getLocations(this.setPrefectures, this.setError);
+    this.$getLanguages(this.setLanguageList, this.setError);
     this.getSpeakers();
 
     bus.$on('contact-speaker', (speaker) => { this.selectedSpeaker = speaker; this.showDialog = true; });
@@ -76,6 +79,9 @@ export default {
   methods: {
     setPrefectures(records) {
       this.prefectures = records;
+    },
+    setLanguageList(records) {
+      this.languageList = records;
     },
     setError(err) {
       this.error = err;


### PR DESCRIPTION
Part 2 of #88

Make sure we're getting language information from the new relation model.

Note when I deploy this to prod, I will need to have a small window of downtime to replace `languages2` with `languages`. I will save the `languages` as `legacy_languages` until we agree this is successful.

Will try to do this around midnight if approved.