### PR TITLE
better color generation, including caching

### DIFF
--- a/web/src/components/TagBox.vue
+++ b/web/src/components/TagBox.vue
@@ -20,8 +20,11 @@
 
 <script>
 // Thank you https://coolors.co/ffadad-ffd6a5-fdffb6-caffbf-9bf6ff-a0c4ff-bdb2ff-ffc6ff
-const softColors = ['#ffadad', '#ffd6a5', '#fdffb6', '#caffbf', '#9bf6ff',
-  '#a0c4ff', '#bdb2ff', '#ffc6ff'];
+// https://coolors.co/feebae-e4ffbb-b3fbdf-9eddff-afbbff-debcff-ffbad6
+const softColors = ['#ffd6a5', '#fdffb6', '#caffbf', '#9bf6ff', '#c1eedd',
+  '#a0c4ff', '#bdb2ff', '#ffc6ff', '#feebae', '#e4ffbb', '#b3fbdf', '#9eddff',
+  '#afbbff', '#ffbad6', '#a7ccff', '#c7bcff', '#ffbdae', '#b0e6ee', '#CDDCF0',
+  '#f7b5c2', '#fbcdc3'];
 
 export default {
   props: {
@@ -30,11 +33,25 @@ export default {
       required: true,
     },
   },
+  data() {
+    return {
+      colorCache: {},
+    };
+  },
   methods: {
     generateColor(tag) {
-      if (tag && tag.length > 0) {
-        const i = tag.charCodeAt(0) % softColors.length;
-        return softColors[i];
+      if (tag) {
+        if (tag in this.colorCache) {
+          return this.colorCache[tag];
+        }
+        let sum = 0;
+        for (let i = 0; i < tag.length; i += 1) {
+          sum += tag.charCodeAt(i);
+        }
+        const i = sum % softColors.length;
+        const color = softColors[i];
+        this.colorCache[tag] = color;
+        return color;
       }
       return softColors[0];
     },


### PR DESCRIPTION
Just a small tweak to improve the tag color generation, so there are fewer duplicates. Also use caching since the computation is more expensive.

Before:
<img width="915" alt="SpeakHer" src="https://user-images.githubusercontent.com/4602369/92302041-d9bd7000-efa3-11ea-89f9-53a3240f11d9.png">


After:
<img width="938" alt="SpeakHer" src="https://user-images.githubusercontent.com/4602369/92302038-d1653500-efa3-11ea-9f91-400bb2076c83.png">
