### PR TITLE
use Google Fonts

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,6 @@
     "axios": "^0.19.2",
     "core-js": "^3.6.4",
     "material-design-icons-iconfont": "^5.0.1",
-    "roboto-fontface": "*",
     "vue": "^2.6.11",
     "vue-i18n": "^8.17.3",
     "vue-router": "^3.1.6",

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -21,6 +21,7 @@
     <meta property="og:image:width" content="957">
     <meta property="og:image:height" content="499">
 
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>SpeakHer</title>
   </head>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4,7 +4,6 @@ import App from './App.vue';
 import router from './router';
 import vuetify from './plugins/vuetify';
 import Airtable from './plugins/airtable';
-import 'roboto-fontface/css/roboto/roboto-fontface.css';
 import '@mdi/font/css/materialdesignicons.css';
 import i18n from './i18n/i18n';
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -7673,11 +7673,6 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-roboto-fontface@*:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/roboto-fontface/-/roboto-fontface-0.10.0.tgz#7eee40cfa18b1f7e4e605eaf1a2740afb6fd71b0"
-  integrity sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g==
-
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"


### PR DESCRIPTION
It would be better using Google Fonts rather than roboto-fontface.
In this case, roboto-fontface has shortcomings:
- not supporting "font-display: swap"
- lack of Netlify's CDN nodes in Japan
- wasting bandwidth of Netlify's free tier

FYI
https://community.netlify.com/t/slow-avg-page-load-time-from-japan/495/2