### PR TITLE
Add recaptcha to Netlify contact form

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -32,7 +32,8 @@
         without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <!--dummy form so netlify knows what's coming-->
-    <form name="contact-speaker" netlify netlify-honeypot="bot-field" hidden>
+    <form name="contact-speaker" netlify netlify-honeypot="bot-field"
+      hidden data-netlify-recaptcha="true">
       <input type="text" name="name" />
       <input type="text" name="email" />
       <textarea name="message"></textarea>

--- a/web/src/components/contact/ContactDialog.vue
+++ b/web/src/components/contact/ContactDialog.vue
@@ -9,6 +9,7 @@
       method="POST"
       data-netlify="true"
       data-netlify-honeypot="bot-field"
+      data-netlify-recaptcha="true"
       @submit.prevent="handleSubmit"
     >
       <input
@@ -43,6 +44,7 @@
           @input="$v.form.message.$touch()"
           @blur="$v.form.message.$touch()"
         />
+        <div data-netlify-recaptcha="true" />
         <v-alert
           v-if="invalid"
           color="error"


### PR DESCRIPTION
Part of #70

Add a recaptcha to the contact form using Netlify's [built-in feature](https://docs.netlify.com/forms/spam-filters/#netlify-provided-recaptcha-2).

Once this is working, I may configure the Google Recaptcha inside the netlify site. 

We can add recaptcha to the nomination at some point, too. Just want to try it out first.