### PR TITLE
Setup development database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
 .vscode
+.env.development
+.env.production
 
 *~

--- a/README.md
+++ b/README.md
@@ -23,30 +23,39 @@ All contributors to this repository must follow the [Code of Conduct](https://ww
 
 Requirements:
 - [Yarn](https://yarnpkg.com/)
+- A free [Airtable account](https://airtable.com)
 
 ### Database connection
 
 This project uses Airtable as a data source. Follow these steps to configure a database on your local environment:
 
-1. Make a copy of `.env.sample` and rename to just `.env`
-2. Get your Airtable API Key on your [Airtable account](https://airtable.com/account)
-3. Edit `.env` to add your `AIRTABLE_API_KEY` and `AIRTABLE_DB_ID`
+1. Make a copy of `.env.sample` and rename it to `.env.development`
+2. Register as a contributor of the Airtable development database [cliking here](https://airtable.com/invite/l?inviteId=invLCTAgGOsrWkXGM&inviteToken=3280cfd046a759fbcf5cb70371fbfab6dd306c9ce9851c2bd50da6de57b04121)
+3. Get your Airtable API Key on your [Airtable account](https://airtable.com/account)
+4. Get the development database ID on the [Dev DB Docs](https://airtable.com/appHpbskGp4dMpqEO/api/docs#javascript/introduction)
+5. Edit `.env.development` to add your `AIRTABLE_API_KEY` and the development `AIRTABLE_DB_ID`
 
-`.env`
+`.env.development`
 ```
+NODE_ENV=development
+VUE_APP_AIRTABLE_DB_ID=[dev database ID here]
 VUE_APP_AIRTABLE_API_KEY=[your api key here]
-VUE_APP_AIRTABLE_DB_ID=[your database ID here]
 ```
 
-You can change the DB configs on `/plugins/airtable.js`.
+You can change other DB configs on `/plugins/airtable.js`.
 
-Further information on the database schema and query documentation [here](https://airtable.com/apprMeMSVqvZhoE6a/api/docs#javascript/introduction).
+Further information on the database schema and query documentation [here](https://airtable.com/appHpbskGp4dMpqEO/api/docs#javascript/introduction) (login with the account you registered on step 2).
 
 
-
-How to run this:
+### Running the app
 
 ```
 cd web
 yarn serve
 ```
+
+Access it on `localhost:8080` on your browser.
+
+### Testing production on local environment
+
+If you have access to the production database, you can setup your production config on `.env.production` and run the app in production mode using the command `yarn serve --mode production`

--- a/web/.env.sample
+++ b/web/.env.sample
@@ -1,2 +1,5 @@
-VUE_APP_AIRTABLE_API_KEY=
-VUE_APP_AIRTABLE_DB_ID=
+# Duplicate this file as .env.development to use as your development configuration
+# Never commit env files with your secret keys to Github!
+NODE_ENV=development
+VUE_APP_AIRTABLE_DB_ID=[dev DB ID here]
+VUE_APP_AIRTABLE_API_KEY=[your api key here]

--- a/web/src/components/nomination/NominateForm.vue
+++ b/web/src/components/nomination/NominateForm.vue
@@ -337,12 +337,10 @@ export default {
       this.clearAlert();
 
       const payload = this.parseFormData();
-      if (process.env.NODE_ENV === 'production') {
-        this.$db('People').create(payload, { typecast: true }, this.afterSave);
-      } else {
+      if (process.env.NODE_ENV === 'development') {
         console.log(payload);
-        this.setAlert('success', this.$t('nominateSpeaker.thanks'));
       }
+      this.$db('People').create(payload, { typecast: true }, this.afterSave);
       this.resetForm();
     },
     // parse the data into the payload format expected by Airtable


### PR DESCRIPTION
References https://github.com/WWCodeTokyo/speak-her-db/issues/137

**Proposed Changes**
Add a Development database to allow anyone to develop safely without access to production database.

**Description of changes in this PR**
- Created a [Dev database on Airtable](https://github.com/WWCodeTokyo/speak-her-db/issues/137#issuecomment-692689209)
- Added instructions on readme on how to setup access to the dev database
- `NODE_ENV=development` will use the dev database, `NODE_ENV=production` will use the production database
- Removed the "dry run" on the submission form for development mode (now it actually saves to the database even in dev mode)

**Testing Plan**
- Pull this branch on your local environment
- Setup `.env.development` according to README instructions
- Run `yarn serve` and check that the app connects to the dev DB and shows the dummy data

For admins that have access to production DB:
- Setup `.env.production` with production access configs
- Run `yarn serve --mode production` and check that the app connects to the production DB and shows real data