### PR TITLE
Fix speaker name on ContactDialog and submission payload

### DIFF
--- a/web/src/components/contact/ContactResult.vue
+++ b/web/src/components/contact/ContactResult.vue
@@ -6,7 +6,7 @@
     <v-card>
       <v-card-title>{{ $t('contact.thanks') }}</v-card-title>
       <v-card-text>
-        {{ $t('contact.forward', [name]) }}
+        {{ $t('contact.forward', [speakerName]) }}
       </v-card-text>
     </v-card>
   </v-dialog>
@@ -19,7 +19,7 @@ export default {
       type: Boolean,
       required: true,
     },
-    name: {
+    speakerName: {
       type: String,
       required: true,
     },

--- a/web/src/views/FindSpeaker.vue
+++ b/web/src/views/FindSpeaker.vue
@@ -8,7 +8,7 @@
     />
     <contact-result
       :show="showSuccess"
-      :name="selectedName"
+      :speaker-name="selectedName"
       @close="showSuccess = false"
     />
     <v-row
@@ -63,7 +63,13 @@ export default {
   }),
   computed: {
     selectedName() {
-      return this.selectedSpeaker ? this.selectedSpeaker.get('name_en') : '';
+      if (this.selectedSpeaker) {
+        if (this.$i18n.locale === 'ja') {
+          return this.selectedSpeaker.get('name_ja') || this.selectedSpeaker.get('name_en') || '';
+        }
+        return this.selectedSpeaker.get('name_en') || '';
+      }
+      return '';
     },
   },
   mounted() {


### PR DESCRIPTION
Solves https://github.com/WWCodeTokyo/speak-her-db/issues/135

### Proposed Changes
- Fix the reference for speaker name on the contact form submission
- Also tweaked it to show the speaker name according to the selected locale (Japanese or English)

### Testing Plan

Production:
- Submit the contact speaker form on the [deploy-preview](https://deploy-preview-147--speak-her-db.netlify.app/) and check [Netlify form submission](https://app.netlify.com/sites/speak-her-db/forms/5ef8717c5e762a00084c9758#item-5f4d9a3fa58b9e2b27fe476b) to see that `Speaker` is now correct (no longer `undefined`).
- Change the locale (JA<>EN) and try the contact form again, check that the speaker name changes according to the selected language (submission to Netlify remains in English, to make it easier for us)

Local:
- Pull this branch and run the app
- Follow the same steps above but you'll see the contact form content on the console instead of submitting to Netlify

### Screenshots

![Screen Shot 2020-09-19 at 7 36 19 PM](https://user-images.githubusercontent.com/1096046/93665206-a6a0d380-faaf-11ea-8fcc-3275639de7c1.png)

![Screen Shot 2020-09-19 at 7 35 58 PM](https://user-images.githubusercontent.com/1096046/93665207-a9032d80-faaf-11ea-97ec-da6e2cae35c4.png)

**Netlify panel**

![Screen Shot 2020-09-19 at 7 34 46 PM](https://user-images.githubusercontent.com/1096046/93665235-d5b74500-faaf-11ea-8bb7-17356c00fab9.png)