### PR TITLE
Bios third person validation

### DIFF
--- a/web/src/components/nomination/NominateForm.vue
+++ b/web/src/components/nomination/NominateForm.vue
@@ -133,6 +133,7 @@ import {
   required, email, minLength, url,
 } from 'vuelidate/lib/validators';
 import japanese from '@/validators/japanese';
+import isThirdPerson from '@/validators/isThirdPerson';
 
 const isTrue = (value) => value;
 const touchMap = new WeakMap();
@@ -166,6 +167,7 @@ export default {
       speaker_bio: {
         required,
         minLength: minLength(BIO_LENGTH),
+        isThirdPerson,
       },
       location: {
         city: { required },
@@ -251,6 +253,7 @@ export default {
       if (!this.$v.form.speaker_bio.$dirty) { return errors; }
       if (!this.$v.form.speaker_bio.required) { errors.push(this.requiredError(this.$t('nominateSpeaker.bio.label'))); }
       if (!this.$v.form.speaker_bio.minLength) { errors.push(this.$t('validations.bioLength', [BIO_LENGTH])); }
+      if (!this.$v.form.speaker_bio.isThirdPerson) { errors.push(this.$t('validations.bioThirdPerson')); }
       return errors;
     },
     cityErrors() {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -99,6 +99,7 @@
     "validations": {
         "allRequired": "All fields are required",
         "bioLength": "Please write at least {0} characters",
+        "bioThirdPerson": "Please write the bio in third person",
         "consentRequired": "Please ask the nominee for permission",
         "emailValid": "Email must be valid",
         "enNameRequired": "English name is required",

--- a/web/src/validators/isThirdPerson.js
+++ b/web/src/validators/isThirdPerson.js
@@ -1,0 +1,8 @@
+// custom vuelidate validator to ensure input does not contain first person
+const isThirdPerson = (value) => {
+  const firstPersonRegex = /((?<=[\s,.:;"’']|^)I(?=[\s,.:;"’'])|わたし|私)/;
+
+  return !firstPersonRegex.test(value);
+};
+
+export default isThirdPerson;

--- a/web/tests/unit/validator-third-person.spec.js
+++ b/web/tests/unit/validator-third-person.spec.js
@@ -17,7 +17,7 @@ describe('isThirdPerson.js', () => {
     expect(isThirdPerson('While in London, I studied things.')).to.be.false;
   });
   it('rejects first person in Japanese', () => {
-    expect(isThirdPerson('私わイタリア人です。')).to.be.false;
+    expect(isThirdPerson('私はイタリア人です。')).to.be.false;
     expect(isThirdPerson('わたし')).to.be.false;
   });
 });

--- a/web/tests/unit/validator-third-person.spec.js
+++ b/web/tests/unit/validator-third-person.spec.js
@@ -1,0 +1,23 @@
+/* eslint-disable no-unused-expressions */
+import { expect } from 'chai';
+import isThirdPerson from '@/validators/isThirdPerson';
+
+describe('isThirdPerson.js', () => {
+  it('accepts third person English', () => {
+    expect(isThirdPerson('She is a member of Women Who Code')).to.be.true;
+  });
+  it('accepts third person in Japanese', () => {
+    expect(isThirdPerson('その後情熱に突き動かされるままに2013年に起業。')).to.be.true;
+  });
+  it('accepts "I" if not first person', () => {
+    expect(isThirdPerson('She works in D&I')).to.be.true;
+  });
+  it('rejects first person in English', () => {
+    expect(isThirdPerson('I\' m a front end developer')).to.be.false;
+    expect(isThirdPerson('While in London, I studied things.')).to.be.false;
+  });
+  it('rejects first person in Japanese', () => {
+    expect(isThirdPerson('私わイタリア人です。')).to.be.false;
+    expect(isThirdPerson('わたし')).to.be.false;
+  });
+});


### PR DESCRIPTION
#119 - custom validation for I and わたし

**Proposed Changes**
Added vuelidate custom validation to find out whether the string in the bio field contains the words I, わたし or 私

*Description of changes in this PR*
New custom validation in its own `.js` file and added validations to the NominateForm. Added unit tests with some sample sentences.
*Japanese translation of the error message missing*

**Testing Plan**
Copy and paste the following examples to verify that the error message appears only when  I, わたし or 私 are in the bio. 

```
Should error:
I'm a full-stack developer with a background in Japanese culture.
I work as a full stack developer for one of the best companies in Japan.

Should pass:
D&I Lead at Hogwarts school of witchcraft and wizardry
She is a volunteer for Women Who Code Tokyo

```