### PR TITLE
Bios persistent hint

### DIFF
--- a/web/src/components/nomination/NominateForm.vue
+++ b/web/src/components/nomination/NominateForm.vue
@@ -44,6 +44,7 @@
       v-model="form.speaker_bio"
       :label="$t('nominateSpeaker.bio.label')"
       :hint="$t('nominateSpeaker.bio.hint')"
+      persistent-hint
       outlined
       :error-messages="speakerBioErrors"
       @input="delayTouch($v.form.speaker_bio)"


### PR DESCRIPTION
Issue #150 
Minor change: hint to persistent-hint, so the hint is not only visible when the field is in focus, but when the form is loaded

*Description of changes in this PR*
Changed hint to persistent-hint to improve consistency of form submissions

**Testing Plan**
Load the page, check if the hint below the speaker bio is visible