### PR TITLE
Bilingual Tag Display

### DIFF
--- a/web/src/components/nomination/TopicsInput.vue
+++ b/web/src/components/nomination/TopicsInput.vue
@@ -41,8 +41,14 @@ export default {
     setTopics(records) {
       this.topics = records.map((topic) => ({
         id: topic.id,
-        text: topic.fields.name,
+        text: this.localizedTopic(topic.fields),
       }));
+    },
+    localizedTopic(topic) {
+      if (this.$i18n.locale === 'ja' && topic.name_ja && topic.name_ja !== '') {
+        return topic.name_ja;
+      }
+      return topic.name;
     },
     setError(err) {
       this.error = err;

--- a/web/src/components/speaker/CardFooter.vue
+++ b/web/src/components/speaker/CardFooter.vue
@@ -80,12 +80,14 @@ export default {
       const tKeys = this.speaker.get('topics');
       const speakerTopics = [];
 
-      tKeys.forEach((topicId) => {
-        const topic = this.topicList.find((elem) => (elem.id === topicId));
-        if (topic) {
-          speakerTopics.push(topic.fields.name);
-        }
-      });
+      if (tKeys) {
+        tKeys.forEach((topicId) => {
+          const topic = this.topicList.find((elem) => (elem.id === topicId));
+          if (topic) {
+            speakerTopics.push({ name: topic.fields.name, name_ja: topic.fields.name_ja });
+          }
+        });
+      }
       return speakerTopics;
     },
   },

--- a/web/src/components/speaker/TagBox.vue
+++ b/web/src/components/speaker/TagBox.vue
@@ -2,17 +2,17 @@
   <v-row class="pa-0 ma-0 d-flex">
     <div
       v-for="tag in tags"
-      :key="tag"
+      :key="tag.name"
       fluid
       class="mr-3"
       align="center"
     >
       <v-chip
-        :color="generateColor(tag)"
+        :color="generateColor(tag.name)"
         label
         class="mb-2"
       >
-        {{ tag }}
+        {{ localizedTag(tag) }}
       </v-chip>
     </div>
   </v-row>
@@ -39,18 +39,24 @@ export default {
     };
   },
   methods: {
-    generateColor(tag) {
-      if (tag) {
-        if (tag in this.colorCache) {
-          return this.colorCache[tag];
+    localizedTag(tag) {
+      if (this.$i18n.locale === 'ja' && tag.name_ja && tag.name_ja !== '') {
+        return tag.name_ja;
+      }
+      return tag.name;
+    },
+    generateColor(name) {
+      if (name) {
+        if (name in this.colorCache) {
+          return this.colorCache[name];
         }
         let sum = 0;
-        for (let i = 0; i < tag.length; i += 1) {
-          sum += tag.charCodeAt(i);
+        for (let i = 0; i < name.length; i += 1) {
+          sum += name.charCodeAt(i);
         }
         const i = sum % softColors.length;
         const color = softColors[i];
-        this.colorCache[tag] = color;
+        this.colorCache[name] = color;
         return color;
       }
       return softColors[0];

--- a/web/src/views/FindSpeaker.vue
+++ b/web/src/views/FindSpeaker.vue
@@ -134,7 +134,7 @@ export default {
       return lastPageEntry > this.speakers.length ? this.speakers.length : lastPageEntry;
     },
   },
-  mounted() {
+  async mounted() {
     api.getLocations(this.setPrefectures, this.setError);
     api.getTopics(this.setTopics, this.setError);
     this.$getLanguages(this.setLanguageList, this.setError);

--- a/web/src/views/FindSpeaker.vue
+++ b/web/src/views/FindSpeaker.vue
@@ -134,7 +134,7 @@ export default {
       return lastPageEntry > this.speakers.length ? this.speakers.length : lastPageEntry;
     },
   },
-  async mounted() {
+  mounted() {
     api.getLocations(this.setPrefectures, this.setError);
     api.getTopics(this.setTopics, this.setError);
     api.getLanguages(this.setLanguageList, this.setError);


### PR DESCRIPTION
Resolves #154 
*Please link to the related issue, using the [references] keyword only if the PR completes the entire issue*

**Proposed Changes**
Better Support for Topics in Japanese language

*Description of changes in this PR*
- [x] Update Airtable to add a `name_ja` column for topics and add translations, removed some duplicates
- [x] Use the locale to toggle between locales for tags
- [x] Update the nomination form to show bilingual tags for selection, while preserving the ability to submit. (I wonder if this will work with autocomplete...)

**Testing Plan**
1) Browse through the speakers and verify that tags appear. Toggle locale to Japanese and ensure that most tags appear in Japanese, and some fall back to English where translations are absent.
2) Nominate a speaker. Add some existing tags using
   a)  the checkbox.
   b) type completion
   c) a custom submission by typing into the input.
