### PR TITLE
Make Japanese name optional on nomination form

### DIFF
--- a/web/src/components/nomination/NominateForm.vue
+++ b/web/src/components/nomination/NominateForm.vue
@@ -171,7 +171,7 @@ export default {
     form: {
       name: {
         en: { required },
-        ja: { required, japanese },
+        ja: { japanese },
       },
       email: {
         required,
@@ -258,7 +258,6 @@ export default {
     japaneseErrors() {
       const errors = [];
       if (!this.$v.form.name.ja.$dirty) { return errors; }
-      if (!this.$v.form.name.ja.required) { errors.push(this.$t('validations.jaNameRequired')); }
       if (!this.$v.form.name.ja.japanese) { errors.push(this.$t('validations.jaNameCharacters')); }
       return errors;
     },

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -101,7 +101,6 @@
         "fieldRequired": "{0}が必要です",
         "invalidForm": "フォームに記入してください",
         "jaNameCharacters": "漢字\/全角かなでお名前を入力してください",
-        "jaNameRequired": "お名前を入力してください",
         "languagesRequired": "話せる言語を選択してください",
         "messageRequired": "スピーカーへの簡単なメッセージが必要です",
         "URLValid": "URLは有効である必要があります",


### PR DESCRIPTION
Resolves #178

**Proposed Changes**

Make the Japanese name on nomination form optional. 

**Testing Plan**

- Go to the nomination form, register yourself without a Japanese name
- Go to airtable and check the published flag
- Switch to Japanese language
- Check the top page, the English name should be used
- Click on the contact speaker button, the contact form should use the English name