### PR TITLE
#136 added message initial value and hint

### DIFF
--- a/web/src/components/contact/ContactDialog.vue
+++ b/web/src/components/contact/ContactDialog.vue
@@ -40,8 +40,9 @@
           v-model="form.message"
           :label="$t('contact.message')"
           :error-messages="messageErrors"
-          clearable
-          hint="Details of your event (who, what, when, where)"
+          :hint="$t('contact.message-hint')"
+          persistent-hint
+          auto-grow
           @input="$v.form.message.$touch()"
           @blur="$v.form.message.$touch()"
         />
@@ -95,11 +96,11 @@ export default {
       },
     },
   },
-  data: () => ({
+  data: (vm) => ({
     form: {
       name: '',
       email: '',
-      message: 'Please introduce yourself to the speaker, providing details of your event (who, what, when, where), and how they might be a good match.',
+      message: vm.$t('contact.message-default'),
     },
   }),
   computed: {

--- a/web/src/components/contact/ContactDialog.vue
+++ b/web/src/components/contact/ContactDialog.vue
@@ -40,6 +40,8 @@
           v-model="form.message"
           :label="$t('contact.message')"
           :error-messages="messageErrors"
+          clearable
+          hint="Details of your event (who, what, when, where)"
           @input="$v.form.message.$touch()"
           @blur="$v.form.message.$touch()"
         />
@@ -97,7 +99,7 @@ export default {
     form: {
       name: '',
       email: '',
-      message: '',
+      message: 'Please introduce yourself to the speaker, providing details of your event (who, what, when, where), and how they might be a good match.',
     },
   }),
   computed: {

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -27,6 +27,8 @@
         "email": "Email",
         "forward": "We'll forward your message to {0}.",
         "message": "Message",
+        "message-hint": "Details of your event (who, what, when, where)",
+        "message-default": "Please introduce yourself to the speaker, providing details of your event (who, what, when, where), and how they might be a good match.",
         "name": "Name",
         "thanks": "Thanks!",
         "title": "Contact {0}?",

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -48,13 +48,3 @@ h2{
 .v-expansion-panel-content__wrap {
   padding: 12px 12px 0px !important;
 }
-
-form[name="contact-speaker"] {
-
-  .v-input__append-inner {
-    position: absolute;
-    right: 0;
-    top: -31px;
-  }
-  
-}

--- a/web/src/styles/main.scss
+++ b/web/src/styles/main.scss
@@ -48,3 +48,13 @@ h2{
 .v-expansion-panel-content__wrap {
   padding: 12px 12px 0px !important;
 }
+
+form[name="contact-speaker"] {
+
+  .v-input__append-inner {
+    position: absolute;
+    right: 0;
+    top: -31px;
+  }
+  
+}


### PR DESCRIPTION
Resolves #136 

**Proposed Changes**
As discussed, I have added an initial value to the textarea, with some text explaining the purpose of the contact and I have made the field clearable. When the user starts typing, a hint will appear with a reminder of what should be in the field.

*Description of changes in this PR*
Changes to the contact form textfield:
- added the initial value in the state
- added clearable option
- added hint 
- styled the `v-input__append-inner` element so that the textfield still takes up 100% of the form width

**Testing Plan**
Click on the contact form for a speaker, the default value should be visible, the field should be clearable and the hint should appear once the user starts typing
