### PR TITLE
organize job / secondary affiliation i18n fields, add persistent hint

### DIFF
--- a/web/src/components/nomination/JobInput.vue
+++ b/web/src/components/nomination/JobInput.vue
@@ -7,7 +7,9 @@
     >
       <v-text-field
         ref="title"
-        :label="$t('nominateSpeaker.jobTitle')"
+        :label="$t('nominateSpeaker.job.title')"
+        :hint="$t('nominateSpeaker.job.hint')"
+        persistent-hint
         outlined
         :value="value.title"
         @input="updateJob('title', $event)"
@@ -21,7 +23,7 @@
       <v-text-field
         ref="company"
         :value="value.company"
-        :label="$t('nominateSpeaker.company')"
+        :label="$t('nominateSpeaker.job.company')"
         outlined
         @input="updateJob('company', $event)"
       />

--- a/web/src/components/nomination/SecondaryAffiliationInput.vue
+++ b/web/src/components/nomination/SecondaryAffiliationInput.vue
@@ -7,8 +7,8 @@
     >
       <v-text-field
         ref="secondary_title"
-        :label="$t('nominateSpeaker.affiliation.title')"
-        :hint="$t('nominateSpeaker.affiliation.hint')"
+        :label="$t('nominateSpeaker.secondaryAffiliation.title')"
+        :hint="$t('nominateSpeaker.secondaryAffiliation.hint')"
         persistent-hint
         outlined
         :value="value.secondary_title"
@@ -23,7 +23,7 @@
       <v-text-field
         ref="secondary_affiliation"
         :value="value.secondary_affiliation"
-        :label="$t('nominateSpeaker.affiliation.company')"
+        :label="$t('nominateSpeaker.secondaryAffiliation.organization')"
         outlined
         @input="updateAffiliation('secondary_affiliation', $event)"
       />

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -69,15 +69,18 @@
             "label": "Speaker Bio"
         },
         "city": "City",
-        "company": "Company",
         "consent": "I have the speaker's permission to submit her information to the SpeakHer database.",
         "email": "Email",
         "error": "Error: {0}",
         "facebook": "Facebook URL",
-        "jobTitle": "Job Title",
-        "affiliation": {
+        "job": {
+            "title": "Job Title",
+            "company": "Company",
+            "hint": "Primary Occupation"
+        },
+        "secondaryAffiliation": {
             "title": "Secondary Role",
-            "company": "Organization",
+            "organization": "Organization",
             "hint": "Academic institutions, volunteer positions, or second jobs"
         },
         "languages": "Languages",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -68,12 +68,16 @@
             "label": "経歴"
         },
         "city": "都市",
-        "company": "会社",
         "consent": "スピーカーの情報をSpeakHerデータベースに登録する許可をスピーカーから得ています。",
         "email": "Eメール",
         "error": "エラー： {0}",
         "facebook": "FacebookのURL",
-        "jobTitle": "職名",
+        "job": {
+            "title": "職名",
+            "company": "会社"
+        },
+        "secondaryAffiliation": {
+        },
         "languages": "言語",
         "linkedIn": "LinkedInのURL",
         "nameEn": "お名前(英語\/ローマ字)",


### PR DESCRIPTION
Resolves #192 

**Proposed Changes**
Various fixes around Primary and secondary job

*Description of changes in this PR*
- Neaten up i18n file structure
- Add a hint to job input
- Use persistent-hint

**Testing Plan**

- View the netlify build
- Check i18n and fallback by toggling between Japanese and English Input
