### PR TITLE
#212 translate press coverage

### DIFF
--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -96,6 +96,9 @@
         "twitter": "TwitterのURL",
         "website": "ウェブサイト"
     },
+    "press": {
+        "title": "掲載メディア"
+    },
     "validations": {
         "allRequired": "全て必須項目です",
         "bioLength": "少なくとも{0}文字入力してください",


### PR DESCRIPTION
Resolves #212

**Proposed Changes**
As we discussed, I translated "Press Coverage" as my first issue.

*Description of changes in this PR*
I translate "Press Coverage" to Japanese "掲載メディア".
It is a common expression to indicate what kind of media broadcast us.

**Testing Plan**
I tested in my local environment.

<img width="908" alt="Screen Shot 2020-12-30 at 17 35 47" src="https://user-images.githubusercontent.com/22512115/103339755-998b7b80-4ac5-11eb-94ab-eb1e6279d7be.png">
