### PR TITLE
(Sub-PR) Add endpoints to fetch resources (Topics, Languages and Locations)

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -10,7 +10,7 @@ gem 'sqlite3', '~> 1.4'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.7'
+gem 'jbuilder', '~> 2.7'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use Active Model has_secure_password

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    jbuilder (2.11.2)
+      activesupport (>= 5.0.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -149,6 +151,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  jbuilder (~> 2.7)
   listen (~> 3.2)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)

--- a/server/README.md
+++ b/server/README.md
@@ -92,16 +92,18 @@ irb(main):004:0> Topic.last
 ```
 You can check how to use the [basic ActiveRecord CRUD methods on RailsGuides](https://guides.rubyonrails.org/active_record_basics.html#crud-reading-and-writing-data).
 
-## Cheking & updating API endpoints (WIP)
+## Cheking & updating API endpoints
 
 Check the API routes typing this command on your terminal
 ```
 $ rails routes
 ```
 
-[RailsGuides about Routes](https://guides.rubyonrails.org/routing.html)
+Alternatively, when your server is running, you can see all available routes at `localhost:3000/rails/info/routes`. Response formats are under the `/views` folder. More info:
+- [RailsGuides about Routes](https://guides.rubyonrails.org/routing.html)
+- [Building JSON responses with JBuilder](https://github.com/rails/jbuilder)
 
-## Writing & running tests (WIP)
+## Writing & running tests
 
 Rails apps come built-in with Minitest. If you're new to Rails or testing, read the [RailsGuides for Testing Rails Apps](https://guides.rubyonrails.org/testing.html).
 

--- a/server/app/controllers/application_controller.rb
+++ b/server/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::API
+  include ActionController::ImplicitRender
+
+  def root
+    if Rails.env == 'development'
+      redirect_to '/rails/info/routes'
+    else
+      redirect_to 'https://speakher.jp'
+    end
+  end
 end

--- a/server/app/controllers/languages_controller.rb
+++ b/server/app/controllers/languages_controller.rb
@@ -1,4 +1,0 @@
-class LanguagesController < ApplicationController
-  def index
-  end
-end

--- a/server/app/controllers/locations_controller.rb
+++ b/server/app/controllers/locations_controller.rb
@@ -1,4 +1,5 @@
 class LocationsController < ApplicationController
   def index
+    @locations = Location.order(code: :asc).all
   end
 end

--- a/server/app/controllers/spoken_languages_controller.rb
+++ b/server/app/controllers/spoken_languages_controller.rb
@@ -1,0 +1,5 @@
+class SpokenLanguagesController < ApplicationController
+  def index
+    @spoken_languages = SpokenLanguage.all
+  end
+end

--- a/server/app/controllers/topics_controller.rb
+++ b/server/app/controllers/topics_controller.rb
@@ -1,4 +1,5 @@
 class TopicsController < ApplicationController
   def index
+    @topics = Topic.all
   end
 end

--- a/server/app/models/speaker.rb
+++ b/server/app/models/speaker.rb
@@ -1,5 +1,5 @@
 class Speaker < ApplicationRecord
   belongs_to :location
   has_and_belongs_to_many :topics # many to many relationship
-  has_and_belongs_to_many :languages # many to many relationship
+  has_and_belongs_to_many :spoken_languages # many to many relationship
 end

--- a/server/app/models/spoken_language.rb
+++ b/server/app/models/spoken_language.rb
@@ -1,3 +1,3 @@
-class Language < ApplicationRecord
+class SpokenLanguage < ApplicationRecord
   has_and_belongs_to_many :speakers # many to many relationship
 end

--- a/server/app/views/locations/index.json.jbuilder
+++ b/server/app/views/locations/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.array! @locations do |location|
   json.id location.id
   json.code location.code
-  json.name location.prefecture
-  json.name_ja location.region
+  json.prefecture location.prefecture
+  json.region location.region
 end

--- a/server/app/views/locations/index.json.jbuilder
+++ b/server/app/views/locations/index.json.jbuilder
@@ -1,0 +1,6 @@
+json.array! @locations do |location|
+  json.id location.id
+  json.code location.code
+  json.name location.prefecture
+  json.name_ja location.region
+end

--- a/server/app/views/spoken_languages/index.json.jbuilder
+++ b/server/app/views/spoken_languages/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @spoken_languages do |language|
+  json.id language.id
+  json.name language.name
+  json.name_ja language.name_ja
+end

--- a/server/app/views/topics/index.json.jbuilder
+++ b/server/app/views/topics/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @topics do |topic|
+  json.id topic.id
+  json.name topic.name
+  json.name_ja topic.name_ja
+end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  get 'languages/index'
-  get 'topics/index'
-  get 'location/index'
+  root 'application#root'
+  get 'languages', to: 'languages#index'
+  get 'topics', to: 'topics#index'
+  get 'locations', to: 'locations#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   root 'application#root'
-  get 'languages', to: 'languages#index'
+  get 'spoken_languages', to: 'spoken_languages#index'
   get 'topics', to: 'topics#index'
   get 'locations', to: 'locations#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   root 'application#root'
-  get 'spoken_languages', to: 'spoken_languages#index'
-  get 'topics', to: 'topics#index'
-  get 'locations', to: 'locations#index'
+
+  resources :spoken_languages, only: :index
+  resources :topics, only: :index
+  resources :locations, only: :index
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/server/db/migrate/20210220073616_change_language_to_spoken_language.rb
+++ b/server/db/migrate/20210220073616_change_language_to_spoken_language.rb
@@ -1,0 +1,5 @@
+class ChangeLanguageToSpokenLanguage < ActiveRecord::Migration[6.0]
+  def change
+    rename_table :languages, :spoken_languages
+  end
+end

--- a/server/db/migrate/20210220073757_change_speaker_language_to_speaker_spoken_language.rb
+++ b/server/db/migrate/20210220073757_change_speaker_language_to_speaker_spoken_language.rb
@@ -1,0 +1,6 @@
+class ChangeSpeakerLanguageToSpeakerSpokenLanguage < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :languages_speakers, :language_id, :spoken_language_id
+    rename_table :languages_speakers, :speakers_spoken_languages
+  end
+end

--- a/server/db/schema.rb
+++ b/server/db/schema.rb
@@ -10,21 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_12_172723) do
-
-  create_table "languages", force: :cascade do |t|
-    t.string "name"
-    t.string "name_ja"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "languages_speakers", id: false, force: :cascade do |t|
-    t.integer "speaker_id", null: false
-    t.integer "language_id", null: false
-    t.index ["language_id"], name: "index_languages_speakers_on_language_id"
-    t.index ["speaker_id"], name: "index_languages_speakers_on_speaker_id"
-  end
+ActiveRecord::Schema.define(version: 2021_02_20_073757) do
 
   create_table "locations", force: :cascade do |t|
     t.integer "code"
@@ -62,11 +48,25 @@ ActiveRecord::Schema.define(version: 2020_12_12_172723) do
     t.index ["location_id"], name: "index_speakers_on_location_id"
   end
 
+  create_table "speakers_spoken_languages", id: false, force: :cascade do |t|
+    t.integer "speaker_id", null: false
+    t.integer "spoken_language_id", null: false
+    t.index ["speaker_id"], name: "index_speakers_spoken_languages_on_speaker_id"
+    t.index ["spoken_language_id"], name: "index_speakers_spoken_languages_on_spoken_language_id"
+  end
+
   create_table "speakers_topics", id: false, force: :cascade do |t|
     t.integer "speaker_id", null: false
     t.integer "topic_id", null: false
     t.index ["speaker_id"], name: "index_speakers_topics_on_speaker_id"
     t.index ["topic_id"], name: "index_speakers_topics_on_topic_id"
+  end
+
+  create_table "spoken_languages", force: :cascade do |t|
+    t.string "name"
+    t.string "name_ja"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "topics", force: :cascade do |t|

--- a/server/db/seeds.rb
+++ b/server/db/seeds.rb
@@ -12,7 +12,7 @@ def self.create_languages
   # Known issue: eval is a security risk. Couldn't make JSON.parse work here...
   array = eval(file_text)
   array.each do |obj|
-    language = Language.where(name: obj[:name]).first_or_initialize
+    language = SpokenLanguage.where(name: obj[:name]).first_or_initialize
     language.update!(obj)
   end
 end

--- a/server/lib/tasks/mock_data.rake
+++ b/server/lib/tasks/mock_data.rake
@@ -12,7 +12,7 @@ namespace :mock do
       speaker.location = Location.find_by(prefecture: obj[:location_id])
 
       obj[:languages].split(',').each do |language|
-        speaker.languages << Language.find_by(name: language)
+        speaker.languages << SpokenLanguage.find_by(name: language)
       end
 
       obj[:topics].split(',').each do |topic|

--- a/server/lib/tasks/mock_data.rake
+++ b/server/lib/tasks/mock_data.rake
@@ -12,7 +12,7 @@ namespace :mock do
       speaker.location = Location.find_by(prefecture: obj[:location_id])
 
       obj[:languages].split(',').each do |language|
-        speaker.languages << SpokenLanguage.find_by(name: language)
+        speaker.spoken_languages << SpokenLanguage.find_by(name: language)
       end
 
       obj[:topics].split(',').each do |topic|

--- a/server/test/controllers/languages_controller_test.rb
+++ b/server/test/controllers/languages_controller_test.rb
@@ -1,9 +1,0 @@
-require 'test_helper'
-
-class LanguagesControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get languages_index_url
-    assert_response :success
-  end
-
-end

--- a/server/test/controllers/location_controller_test.rb
+++ b/server/test/controllers/location_controller_test.rb
@@ -1,9 +1,0 @@
-require 'test_helper'
-
-class LocationControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get location_index_url
-    assert_response :success
-  end
-
-end

--- a/server/test/controllers/locations_controller_test.rb
+++ b/server/test/controllers/locations_controller_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class LocationsControllerTest < ActionDispatch::IntegrationTest
+  test 'should get index' do
+    get locations_path, headers: { "accept": 'application/json' }
+    assert_response :success
+  end
+
+  test 'index returns a list of locations' do
+    locations_hash = locations.map do |location|
+      {
+        id: location.id,
+        code: location.code,
+        prefecture: location.prefecture,
+        region: location.region
+      }
+    end
+    expected_response = JSON.parse(locations_hash.to_json)
+
+    get locations_path, headers: { "accept": 'application/json' }
+    res = JSON.parse(response.body)
+    assert_equal(res.to_set, expected_response.to_set)
+  end
+
+end

--- a/server/test/controllers/spoken_languages_controller_test.rb
+++ b/server/test/controllers/spoken_languages_controller_test.rb
@@ -1,9 +1,24 @@
 require 'test_helper'
 
 class SpokenLanguagesControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get spoken_languages_index_url
+  test 'should get index' do
+    get spoken_languages_path, headers: { "accept": 'application/json' }
     assert_response :success
+  end
+
+  test 'index returns a list of spoken_languages' do
+    spoken_languages_hash = spoken_languages.map do |topic|
+      {
+        id: topic.id,
+        name: topic.name,
+        name_ja: topic.name_ja
+      }
+    end
+    expected_response = JSON.parse(spoken_languages_hash.to_json)
+
+    get spoken_languages_path, headers: { "accept": 'application/json' }
+    res = JSON.parse(response.body)
+    assert_equal(res.to_set, expected_response.to_set)
   end
 
 end

--- a/server/test/controllers/spoken_languages_controller_test.rb
+++ b/server/test/controllers/spoken_languages_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class SpokenLanguagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get spoken_languages_index_url
+    assert_response :success
+  end
+
+end

--- a/server/test/controllers/topics_controller_test.rb
+++ b/server/test/controllers/topics_controller_test.rb
@@ -1,9 +1,24 @@
 require 'test_helper'
 
 class TopicsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get topics_index_url
+  test 'should get index' do
+    get topics_path, headers: { "accept": 'application/json' }
     assert_response :success
   end
 
+  test 'index returns a list of topics' do
+    topics_hash = topics.map do |topic|
+      {
+        id: topic.id,
+        name: topic.name,
+        name_ja: topic.name_ja
+      }
+    end
+    expected_response = JSON.parse(topics_hash.to_json)
+
+    get topics_path, headers: { "accept": 'application/json' }
+    res = JSON.parse(response.body)
+    assert_equal(res.to_set, expected_response.to_set)
+  end
 end
+

--- a/server/test/fixtures/locations.yml
+++ b/server/test/fixtures/locations.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  code:
-  prefecture: MyString
-  region: MyString
+tokyo:
+  code: 1
+  prefecture: 'Tokyo'
+  region: 'Tokyo'
 
-two:
-  code:
-  prefecture: MyString
-  region: MyString
+kanagawa:
+  code: 2
+  prefecture: 'Kanagawa'
+  region: 'Kanagawa'

--- a/server/test/fixtures/locations.yml
+++ b/server/test/fixtures/locations.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  ord: 
+  code:
   prefecture: MyString
   region: MyString
 
 two:
-  ord: 
+  code:
   prefecture: MyString
   region: MyString

--- a/server/test/fixtures/speakers.yml
+++ b/server/test/fixtures/speakers.yml
@@ -1,45 +1,45 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 published_speaker:
-    name_en: Kana Mitomo,
-    name_ja: 御供 香南,
-    published: true,
-    pronouns: she/her,
-    city: Minato-ku,
-    location_id: Tokyo / 東京都, # TODO: Add reference here
-    job_title: CEO,
-    company: Bla Inc.,
-    email: xyz122@email.com,
-    topics: Leadership,LGBTQIA+,Social Impact, #TODO: Add references here
-    spoken_languages: English,Japanese,French, #TODO: Add references here
-    speaker_bio: 崎ル大事変述クラ白国ぜぐぶ年果8進さびや期困すど写自ンよて総世ツ観日れづつ努世ぽぜがせ近並へぱ務利江仙リせんび。引稲除メコヤ午止辞トヨツホ入29野ルチシ止会ヒヘ済判オホワム処正ケ唱68朝給れや保回月む高疑7店建ッむれそ。場シツ河武ぽも問必ア般投む供壊わク予目ム猿馬フネヒク新狙ヨリト分格どはゃ間水マ本4山ぴふの告嗅ツ大手さぽんら載能ドくる雅程媛緒ルにも。,
-    photo_url: http://lorempixel.com/400/300/animals/,
-    linkedin_url: http://dfrirvbl.tcxlpvlt.org,
-    twitter_url: http://dfrirvbl.tcxlpvlt.org,
-    website_url: http://dfrirvbl.tcxlpvlt.org,
-    facebook_url: http://dfrirvbl.tcxlpvlt.org,
-    submitter_name: Kana Mitomo,
-    submitter_email: xyz122@email.com,
+    name_en: 'Kana Mitomo'
+    name_ja: '御供 香南'
+    published: true
+    pronouns: 'she/her'
+    city: 'Minato-ku'
+    location_id: tokyo
+    job_title: 'CEO'
+    company: 'Bla Inc.'
+    email: 'xyz122@email.com'
+    topics: [leadership, tech, social_impact]
+    spoken_languages: [english, japanese]
+    speaker_bio: '崎ル大事変述クラ白国ぜぐぶ年果8進さびや期困すど写自ンよて総世ツ観日れづつ努世ぽぜがせ近並へぱ務利江仙リせんび。引稲除メコヤ午止辞トヨツホ入29野ルチシ止会ヒヘ済判オホワム処正ケ唱68朝給れや保回月む高疑7店建ッむれそ。場シツ河武ぽも問必ア般投む供壊わク予目ム猿馬フネヒク新狙ヨリト分格どはゃ間水マ本4山ぴふの告嗅ツ大手さぽんら載能ドくる雅程媛緒ルにも。'
+    photo_url: 'https://picsum.photos/200'
+    linkedin_url: 'http://dfrirvbl.tcxlpvlt.org'
+    twitter_url: 'http://dfrirvbl.tcxlpvlt.org'
+    website_url: 'http://dfrirvbl.tcxlpvlt.org'
+    facebook_url: 'http://dfrirvbl.tcxlpvlt.org'
+    submitter_name: 'Kana Mitomo'
+    submitter_email: 'xyz122@email.com'
     consent: true
 
 unpublished_speaker:
-    name_en: Kana Mitomo,
-    name_ja: 御供 香南,
-    published: false,
-    pronouns: she/her,
-    city: Minato-ku,
-    location_id: Tokyo / 東京都, # TODO: Add reference here
-    job_title: CEO,
-    company: Bla Inc.,
-    email: xyz122@email.com,
-    topics: Leadership,LGBTQIA+,Social Impact, # TODO: Add references here
-    spoken_languages: English,Japanese,French, # TODO: Add references here
-    speaker_bio: 崎ル大事変述クラ白国ぜぐぶ年果8進さびや期困すど写自ンよて総世ツ観日れづつ努世ぽぜがせ近並へぱ務利江仙リせんび。引稲除メコヤ午止辞トヨツホ入29野ルチシ止会ヒヘ済判オホワム処正ケ唱68朝給れや保回月む高疑7店建ッむれそ。場シツ河武ぽも問必ア般投む供壊わク予目ム猿馬フネヒク新狙ヨリト分格どはゃ間水マ本4山ぴふの告嗅ツ大手さぽんら載能ドくる雅程媛緒ルにも。,
-    photo_url: http://lorempixel.com/400/300/animals/,
-    linkedin_url: http://dfrirvbl.tcxlpvlt.org,
-    twitter_url: http://dfrirvbl.tcxlpvlt.org,
-    website_url: http://dfrirvbl.tcxlpvlt.org,
-    facebook_url: http://dfrirvbl.tcxlpvlt.org,
-    submitter_name: Kana Mitomo,
-    submitter_email: xyz122@email.com,
+    name_en: 'Kana Mitomo'
+    name_ja: '御供 香南'
+    published: false
+    pronouns: 'she/her'
+    city: 'Minato-ku'
+    location_id: kanagawa
+    job_title: 'CEO'
+    company: 'Bla Inc.'
+    email: 'xyz122@email.com'
+    topics: [tech, arts]
+    spoken_languages: [english, japanese, french]
+    speaker_bio: '崎ル大事変述クラ白国ぜぐぶ年果8進さびや期困すど写自ンよて総世ツ観日れづつ努世ぽぜがせ近並へぱ務利江仙リせんび。引稲除メコヤ午止辞トヨツホ入29野ルチシ止会ヒヘ済判オホワム処正ケ唱68朝給れや保回月む高疑7店建ッむれそ。場シツ河武ぽも問必ア般投む供壊わク予目ム猿馬フネヒク新狙ヨリト分格どはゃ間水マ本4山ぴふの告嗅ツ大手さぽんら載能ドくる雅程媛緒ルにも。'
+    photo_url: 'https://picsum.photos/200'
+    linkedin_url: 'http://dfrirvbl.tcxlpvlt.org'
+    twitter_url: 'http://dfrirvbl.tcxlpvlt.org'
+    website_url: 'http://dfrirvbl.tcxlpvlt.org'
+    facebook_url: 'http://dfrirvbl.tcxlpvlt.org'
+    submitter_name: 'Kana Mitomo'
+    submitter_email: 'xyz122@email.com'
     consent: true

--- a/server/test/fixtures/speakers.yml
+++ b/server/test/fixtures/speakers.yml
@@ -1,25 +1,45 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name_en: MyString
-  name_ja: MyString
-  city: MyString
-  job_title: MyString
-  company: MyString
-  secondary_affiliation: MyString
-  speaker_bio: MyString
-  twitter_url: MyString
-  website_url: MyString
-  facebook_url: MyString
+published_speaker:
+    name_en: Kana Mitomo,
+    name_ja: 御供 香南,
+    published: true,
+    pronouns: she/her,
+    city: Minato-ku,
+    location_id: Tokyo / 東京都, # TODO: Add reference here
+    job_title: CEO,
+    company: Bla Inc.,
+    email: xyz122@email.com,
+    topics: Leadership,LGBTQIA+,Social Impact, #TODO: Add references here
+    spoken_languages: English,Japanese,French, #TODO: Add references here
+    speaker_bio: 崎ル大事変述クラ白国ぜぐぶ年果8進さびや期困すど写自ンよて総世ツ観日れづつ努世ぽぜがせ近並へぱ務利江仙リせんび。引稲除メコヤ午止辞トヨツホ入29野ルチシ止会ヒヘ済判オホワム処正ケ唱68朝給れや保回月む高疑7店建ッむれそ。場シツ河武ぽも問必ア般投む供壊わク予目ム猿馬フネヒク新狙ヨリト分格どはゃ間水マ本4山ぴふの告嗅ツ大手さぽんら載能ドくる雅程媛緒ルにも。,
+    photo_url: http://lorempixel.com/400/300/animals/,
+    linkedin_url: http://dfrirvbl.tcxlpvlt.org,
+    twitter_url: http://dfrirvbl.tcxlpvlt.org,
+    website_url: http://dfrirvbl.tcxlpvlt.org,
+    facebook_url: http://dfrirvbl.tcxlpvlt.org,
+    submitter_name: Kana Mitomo,
+    submitter_email: xyz122@email.com,
+    consent: true
 
-two:
-  name_en: MyString
-  name_ja: MyString
-  city: MyString
-  job_title: MyString
-  company: MyString
-  secondary_affiliation: MyString
-  speaker_bio: MyString
-  twitter_url: MyString
-  website_url: MyString
-  facebook_url: MyString
+unpublished_speaker:
+    name_en: Kana Mitomo,
+    name_ja: 御供 香南,
+    published: false,
+    pronouns: she/her,
+    city: Minato-ku,
+    location_id: Tokyo / 東京都, # TODO: Add reference here
+    job_title: CEO,
+    company: Bla Inc.,
+    email: xyz122@email.com,
+    topics: Leadership,LGBTQIA+,Social Impact, # TODO: Add references here
+    spoken_languages: English,Japanese,French, # TODO: Add references here
+    speaker_bio: 崎ル大事変述クラ白国ぜぐぶ年果8進さびや期困すど写自ンよて総世ツ観日れづつ努世ぽぜがせ近並へぱ務利江仙リせんび。引稲除メコヤ午止辞トヨツホ入29野ルチシ止会ヒヘ済判オホワム処正ケ唱68朝給れや保回月む高疑7店建ッむれそ。場シツ河武ぽも問必ア般投む供壊わク予目ム猿馬フネヒク新狙ヨリト分格どはゃ間水マ本4山ぴふの告嗅ツ大手さぽんら載能ドくる雅程媛緒ルにも。,
+    photo_url: http://lorempixel.com/400/300/animals/,
+    linkedin_url: http://dfrirvbl.tcxlpvlt.org,
+    twitter_url: http://dfrirvbl.tcxlpvlt.org,
+    website_url: http://dfrirvbl.tcxlpvlt.org,
+    facebook_url: http://dfrirvbl.tcxlpvlt.org,
+    submitter_name: Kana Mitomo,
+    submitter_email: xyz122@email.com,
+    consent: true

--- a/server/test/fixtures/spoken_languages.yml
+++ b/server/test/fixtures/spoken_languages.yml
@@ -1,9 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
-  name_ja: MyString
+english:
+  name: 'English'
+  name_ja: '英語'
 
-two:
-  name: MyString
-  name_ja: MyString
+japanese:
+  name: 'Japanese'
+  name_ja: '日本語'
+
+french:
+  name: 'French'
+  name_ja: 'フランス語'

--- a/server/test/fixtures/spoken_languages.yml
+++ b/server/test/fixtures/spoken_languages.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name_en: MyString
+  name: MyString
   name_ja: MyString
 
 two:
-  name_en: MyString
+  name: MyString
   name_ja: MyString

--- a/server/test/fixtures/topics.yml
+++ b/server/test/fixtures/topics.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name_en: MyString
+  name: MyString
   name_ja: MyString
 
 two:
-  name_en: MyString
+  name: MyString
   name_ja: MyString

--- a/server/test/fixtures/topics.yml
+++ b/server/test/fixtures/topics.yml
@@ -1,9 +1,17 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
-  name_ja: MyString
+leadership:
+  name: 'Leadership'
+  name_ja: 'リーダーシップ'
 
-two:
-  name: MyString
-  name_ja: MyString
+tech:
+  name: 'Tech'
+  name_ja: 'テック'
+
+social_impact:
+  name: 'Social impact'
+  name_ja: 'ソーシャルインパクト'
+
+arts:
+  name: 'Arts'
+  name_ja: '芸術'

--- a/server/test/models/spoken_language_test.rb
+++ b/server/test/models/spoken_language_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class LanguageTest < ActiveSupport::TestCase
+class SpokenLanguageTest < ActiveSupport::TestCase
   # test "the truth" do
   #   assert true
   # end


### PR DESCRIPTION
**Issue: https://github.com/WWCodeTokyo/speak-her-db/issues/224**
**This is a sub-PR to merged to #210 Rails Backend.**

This PR implements the following changes:
- Adds the fetch/index endpoint to all the core models (Topics, Languages and Locations)
- Refactors the model `Language` and its API endpoint to `SpokenLanguage` to avoid conflicts with Rails internationalization (`language` seems to be a reserved word)
- Add a simple logic for the root `/` path to show the available API routes if you access the server on your browser in development mode. If it's not development mode, it will redirect to the production site (https://speakher.jp)
- Fix and implement tests for the API endpoints

Current available endpoints:
```
GET / (root)          => redirects to production site or shows the API routes on the browser if in dev mode
GET /topics           => responds with a JSON with the list of all topics
GET /locations        => responds with a JSON with the list of all locations, in ascending order by code
GET /spoken_languages => responds with a JSON with the list of all languages
```