### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project uses Airtable as a data source. Follow these steps to configure a d
 1. Go into the web directory: `cd web`
 2. Make a copy of `.env.sample` and rename it to `.env.development`
 3. Register as a contributor of the Airtable development database [clicking here](https://airtable.com/invite/l?inviteId=invLCTAgGOsrWkXGM&inviteToken=3280cfd046a759fbcf5cb70371fbfab6dd306c9ce9851c2bd50da6de57b04121)
-4. Get your Airtable API Key on your [Airtable account](https://airtable.com/account)
+4. Create a Personal Access Token on your [Airtable account](https://airtable.com/create/tokens)
 5. Get the development database ID on the [Dev DB Docs](https://airtable.com/appHpbskGp4dMpqEO/api/docs#javascript/introduction)
 6. Edit `.env.development` to add your `AIRTABLE_API_KEY` and the development `AIRTABLE_DB_ID`
 


### PR DESCRIPTION
Update readme instructions to use Airtable Personal Access Tokens instead of API Key (deprecated since February 2023).
